### PR TITLE
Integrate Chrome's proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ interface DocumentEventMap {
 }
 
 interface AutofillEvent extends Event {
-  readonly values:         ReadonlyArray<readonly [HTMLElement, string]>;
+  readonly values:         ReadonlyArray<readonly [HTMLElement, string | boolean]>;
   readonly triggerElement: HTMLElement | null;
   readonly refill:         () => Promise<void> | null;
 }
@@ -56,6 +56,7 @@ The event's target is the `document` because the Autofill implementation's notio
 The event does not bubble and is not cancelable.
 
 The event's `values` property maps each element to value to be autofilled.
+If the element is a checkbox or radio button, the value is a `boolean`; otherwise it is a `string`.
 It is not guaranteed that the element actually has that value after the autofill.
 Examples where the value may differ after the autofill include:
 an event handler changes or removes the element;


### PR DESCRIPTION
How do you feel about adopting the proposal from [issue 15](https://github.com/WICG/address-autofill/issues/15)?

"Integrate" in the PR title is perhaps a euphemism because I just replaced the entire section – I acknowledge this PR is perhaps a bit radical :).

I've made some small additions and adjustments in the PR compared to the text from [issue 15](https://github.com/WICG/address-autofill/issues/15).

The technical changes are of the PR compared to the status quo are:
- The old versions says "perform[ing] the autofill operation [...] is left to the browser after [...] the relevant Promise is resolved". The new version is not blocking the initial fill. As a result I deleted the paragraph about the Autofill implementation providing alternative information.
- The new version changes the type from `refill` from something like `(fn: () => Promise<void>) => void` to `() => Promise<void>`.
- The new version fires the event before, not after doing the autofill. No strong opinion on this. The motivation is to allow the website to distinguish between autofills and manual fills more easily, but maybe there's a better way for it (discussion is going in [issue 15](https://github.com/WICG/address-autofill/issues/15).